### PR TITLE
Fix pagination issue for bitbucket. Fix repo identification issue

### DIFF
--- a/frontend/src/api/bitbucket.ts
+++ b/frontend/src/api/bitbucket.ts
@@ -99,7 +99,13 @@ export const retrieveBitbucketUserRepositories = async (
   page = 1,
   per_page = 30,
 ) => {
-  const response = await bitbucket.get<{ values: BitbucketRepository[] }>(
+  const response = await bitbucket.get<{
+    values: BitbucketRepository[];
+    pagelen: number;
+    size: number;
+    page: number;
+    next: string;
+  }>(
     `repositories/paytmteam`,
     {
       headers: {
@@ -113,8 +119,7 @@ export const retrieveBitbucketUserRepositories = async (
     },
   );
 
-  const link = response.headers.link ?? "";
-  const nextPage = extractNextPageFromLink(link);
+  const nextPage = response.data.next ? page + 1 : null;
 
   return { data: response.data.values, nextPage };
 };

--- a/frontend/src/components/features/bitbucket/bitbucket-repo-selector.tsx
+++ b/frontend/src/components/features/bitbucket/bitbucket-repo-selector.tsx
@@ -105,6 +105,9 @@ export function BitbucketRepositorySelector({
               key={repo.name}
               value={repo.name}
               className="data-[selected=true]:bg-default-100"
+              classNames={{
+                title: "break-words whitespace-normal"
+              }}
               textValue={repo.full_name}
             >
               {repo.full_name}
@@ -120,6 +123,9 @@ export function BitbucketRepositorySelector({
               key={repo.name}
               value={repo.name}
               className="data-[selected=true]:bg-default-100"
+              classNames={{
+                title: "break-words whitespace-normal"
+              }}
               textValue={repo.full_name}
             >
               {repo.full_name}


### PR DESCRIPTION
**Bitbucket pagination and repo name visibility**

---
- Bitbucket pagination was not working. Github specific regex was getting used to fetch the next page. Now identifying if the next page exists and simply incrementing it.
- When the prefix is same for repo names, it's hard to distinguish which one is getting selected. Add work-break on title for visibility
---

